### PR TITLE
revert get and clean property value to original; add resetLoopDocumen…

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -304,7 +304,6 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
 
     func pumpManagerDidUpdateState(_ pumpManager: PumpManager) {
         rawPumpManager = pumpManager.rawValue
-        UserDefaults.standard.clearLegacyPumpManagerRawValue()
         if self.pumpManager == nil, let newPumpManager = pumpManager as? PumpManagerUI {
             self.pumpManager = newPumpManager
         }

--- a/FreeAPS/Sources/APS/Extensions/UserDefaultsExtensions.swift
+++ b/FreeAPS/Sources/APS/Extensions/UserDefaultsExtensions.swift
@@ -25,11 +25,11 @@ extension UserDefaults {
     }
 
     var legacyPumpManagerRawValue: PumpManager.RawValue? {
-        dictionary(forKey: Key.legacyPumpManagerState.rawValue)
+        dictionary(forKey: Key.legacyPumpManagerRawValue.rawValue)
     }
 
     func clearLegacyPumpManagerRawValue() {
-        set(nil, forKey: Key.legacyPumpManagerState.rawValue)
+        set(nil, forKey: Key.legacyPumpManagerRawValue.rawValue)
     }
 
     var legacyCGMManagerRawValue: CGMManager.RawValue? {

--- a/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
@@ -62,6 +62,19 @@ extension Settings {
         func hideSettingsModal() {
             hideModal()
         }
+
+        func resetLoopDocuments() {
+            guard let localDocuments = try? FileManager.default.url(
+                for: .documentDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            ) else {
+                preconditionFailure("Could not get a documents directory URL.")
+            }
+            let storageURL = localDocuments.appendingPathComponent("PumpManagerState" + ".plist")
+            try? FileManager.default.removeItem(at: storageURL)
+        }
     }
 }
 

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -61,6 +61,12 @@ extension Settings {
                                     .frame(maxWidth: .infinity, alignment: .trailing)
                                     .buttonStyle(.borderedProminent)
                             }
+                            HStack {
+                                Text("Delete Pump State nlist")
+                                Button("Delete") { state.resetLoopDocuments() }
+                                    .frame(maxWidth: .infinity, alignment: .trailing)
+                                    .buttonStyle(.borderedProminent)
+                            }
                         }
                         Group {
                             Text("Preferences")


### PR DESCRIPTION
I think this fixes issues found.  There is also a new a new Settings - Debug Option to delete the nlist doc for testing Dev -> PR multiple times.  We may not want to keep this Debug Option in code after testing this PR is completed though.

Tested this on Simulator.  Process:

1. Add patch
2. Install PR.  Go to Setting - Debug Options - Tap "Delete Pump State nlist" button
3. Install dev branch
4. Add Omnipod Dash - "No pod" is displayed on HUD.
5. Install PR. Observe "No pod" is displayed on HUD for Omnipod Dash.